### PR TITLE
Improvements in ru_ru.json

### DIFF
--- a/src/main/resources/assets/recursiveresources/lang/ru_ru.json
+++ b/src/main/resources/assets/recursiveresources/lang/ru_ru.json
@@ -5,12 +5,15 @@
       "z-a": "Я-А"
     },
     "view": {
-      "folder": "Просмотр папок",
-      "flat": "Плоский вид"
+      "folder": "Папки",
+      "flat": "Все"
     },
     "folder": {
-      "back": "(Назад)",
-      "folder": "(Папка)"
+      "back": "§oНазад",
+      "folder": "§oПапка"
     }
-  }
+  },
+  "modmenu.nameTranslation.recursiveresources": "Рекурсивные ресурсы",
+  "modmenu.summaryTranslation.recursiveresources": "Улучшенное меню наборов ресурсов с поддержкой папок.",
+  "modmenu.descriptionTranslation.recursiveresources": "Улучшенный вид меню наборов ресурсов с возможностью их сортировки, поиска по имени и описанию, а также поддержкой чтения из папок для лучшей организации пространства."
 }

--- a/src/main/resources/assets/recursiveresources/lang/ru_ru.json
+++ b/src/main/resources/assets/recursiveresources/lang/ru_ru.json
@@ -9,8 +9,8 @@
       "flat": "Все"
     },
     "folder": {
-      "back": "§oНазад",
-      "folder": "§oПапка"
+      "back": "(Назад)",
+      "folder": "(Папка)"
     }
   },
   "modmenu.nameTranslation.recursiveresources": "Рекурсивные ресурсы",

--- a/src/main/resources/assets/recursiveresources/lang/ru_ru.json
+++ b/src/main/resources/assets/recursiveresources/lang/ru_ru.json
@@ -13,7 +13,6 @@
       "folder": "(Папка)"
     }
   },
-  "modmenu.nameTranslation.recursiveresources": "Рекурсивные ресурсы",
   "modmenu.summaryTranslation.recursiveresources": "Улучшенное меню наборов ресурсов с поддержкой папок.",
   "modmenu.descriptionTranslation.recursiveresources": "Улучшенный вид меню наборов ресурсов с возможностью их сортировки, поиска по имени и описанию, а также поддержкой чтения из папок для лучшей организации пространства."
 }


### PR DESCRIPTION
Since there are corrections and uncommon additions here, this PR requires discussion.

First of all, `flat view`. I think in Russian it is closer to `Сплошной просмотр`, since the direct translation of Flat as `Плоский` is at least illogical. Because, well, regardless of switching this setting, the resource packs menu remains "плоским".
~~Also `Сплошной просмотр` doesn't fit into the button space and not used in Russian localizations of program interfaces anyway~~ Nevermind, I forgot that we can use `вид` instead of `просмотр`...
Instead, the common localized options are the ones I suggested in this PR. So @Kikugie , since I'm changing your translation, I need to know if you agree with that or not.

Secondly, I suggest to make the folder labels less noticeable so that they do not distract attention the user's attention and do not look like descriptions of resource packs. This is achieved by italicizing it and getting rid of parentheses. But this is already a change in the original style, so, enjarai, your opinion is necessary. If you don't like it, I'll return the original form.

And finally, I added translations for ModMenu. There is nothing unusual here – summary was taken from Modrinth, but the very existence of a translation for the mod name also needs to be discussed. The raw translation `Рекурсивные ресурсы` sounds good in Russian, so with your permission I will add this too. If not, just tell me.