### PR TITLE
1.21 dev

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ bin/
 run/
 
 *.ase
+/radle-version/

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 plugins {
-    id 'fabric-loom' version '1.6-SNAPSHOT'
+    id 'fabric-loom' version '1.7-SNAPSHOT'
     id 'maven-publish'
-    id 'me.fallenbreath.yamlang' version '1.2.1'
+    id 'me.fallenbreath.yamlang' version '1.3.1'
 }
 
 sourceCompatibility = JavaVersion.VERSION_21
@@ -53,7 +53,7 @@ version = "$version+$minecraft_version"
 // ensure that the encoding is set to UTF-8, no matter what the system default is
 // this fixes some edge cases with special characters not displaying correctly
 // see http://yodaconditions.net/blog/fix-for-java-file-encoding-problems-with-gradle.html
-tasks.withType(JavaCompile) {
+tasks.withType(JavaCompile).configureEach {
     options.encoding = "UTF-8"
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,17 +3,17 @@ org.gradle.jvmargs=-Xmx1G
 
 # Fabric Properties
 # check these on https://fabricmc.net/use
-minecraft_version=1.20.6
-yarn_mappings=1.20.6+build.1
+minecraft_version=1.21
+yarn_mappings=1.21+build.2
 loader_version=0.15.11
 
 # Mod Properties
-mod_version=2.5.2
+mod_version=2.5.3-dev
 maven_group=nl.enjarai
 archives_base_name=recursive-resources
 
-fabric_version=0.97.8+1.20.6
+fabric_version=0.100.3+1.21
 # https://modrinth.com/mod/modmenu/versions
-modmenu_version=10.0.0-beta.1
+modmenu_version=11.0.0
 shared_resources_version=1.8.0
 cicada_version=0.7.2+1.20.5-and-above

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.8-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,6 +1,5 @@
 pluginManagement {
     repositories {
-        jcenter()
         maven { url "https://maven.fabricmc.net/" }
         maven { url "https://maven.enjarai.nl/mirrors"}
         mavenCentral()

--- a/src/main/java/nl/enjarai/recursiveresources/RecursiveResources.java
+++ b/src/main/java/nl/enjarai/recursiveresources/RecursiveResources.java
@@ -27,6 +27,6 @@ public class RecursiveResources implements ClientModInitializer, CicadaEntrypoin
     }
 
     public static Identifier id(String path) {
-        return new Identifier(MOD_ID, path);
+        return Identifier.of(MOD_ID, path);
     }
 }

--- a/src/main/java/nl/enjarai/recursiveresources/pack/FolderMeta.java
+++ b/src/main/java/nl/enjarai/recursiveresources/pack/FolderMeta.java
@@ -50,23 +50,6 @@ public record FolderMeta(Path icon, String description, List<Path> packs, boolea
 
                 if (Files.exists(metaFile)) {
                     meta = FolderMeta.load(metaFile);
-
-                    //if contents of folder have changed, refresh meta file
-                    if (meta.packs().stream().anyMatch(pack -> !Files.exists(rootedFolder.resolve(pack)))) {
-                        meta = FolderMeta.DEFAULT;
-
-                        try (Stream<Path> packs = Files.list(rootedFolder)) {
-                            meta = meta.getRefreshed(packs
-                                    .filter(ResourcePackUtils::isPack)
-                                    .map(Path::normalize)
-                                    .map(rootedFolder::relativize)
-                                    .toList()
-                            );
-                            meta.save(metaFile);
-                        } catch (Exception e) {
-                            RecursiveResources.LOGGER.error("Failed to process meta file for folder " + folder, e);
-                        }
-                    }
                 }
 
                 if (!meta.errored()) {

--- a/src/main/java/nl/enjarai/recursiveresources/pack/FolderMeta.java
+++ b/src/main/java/nl/enjarai/recursiveresources/pack/FolderMeta.java
@@ -28,7 +28,7 @@ public record FolderMeta(Path icon, String description, List<Path> packs, boolea
     public static final Codec<FolderMeta> CODEC = RecordCodecBuilder.create(instance -> instance.group(
             Codec.STRING.xmap(Path::of, Path::toString).fieldOf("icon").forGetter(FolderMeta::icon),
             Codec.STRING.fieldOf("description").forGetter(FolderMeta::description),
-            Codec.STRING.xmap(Path::of, Path::toString).listOf().fieldOf("packs").forGetter(FolderMeta::packs),
+            Codec.STRING.xmap(Path::of, Path::toString).listOf().fieldOf("packs").forGetter(FolderMeta::packs), // TODO only add packs that arent in any other meta automatically
             Codec.BOOL.fieldOf("hidden").forGetter(FolderMeta::hidden)
     ).apply(instance, FolderMeta::new));
 

--- a/src/main/java/nl/enjarai/recursiveresources/pack/FolderPack.java
+++ b/src/main/java/nl/enjarai/recursiveresources/pack/FolderPack.java
@@ -30,7 +30,7 @@ public class FolderPack implements ResourcePackOrganizer.Pack {
                 // Ensure the path only contains "a-z0-9_.-" characters
                 relativePath = relativePath.toLowerCase().replaceAll("[^a-zA-Z0-9_.-]", "_");
 
-                Identifier id = RecursiveResources.id("textures/gui/folder_icons/" + relativePath + "/" + icon.getFileName());
+                Identifier id = RecursiveResources.id("textures/gui/custom_folders/" + relativePath + "/" + icon.getFileName());
                 MinecraftClient.getInstance().getTextureManager().registerTexture(id, new NativeImageBackedTexture(NativeImage.read(stream)));
                 return id;
             } catch (Exception e) {

--- a/src/main/java/nl/enjarai/recursiveresources/pack/FolderPack.java
+++ b/src/main/java/nl/enjarai/recursiveresources/pack/FolderPack.java
@@ -30,7 +30,7 @@ public class FolderPack implements ResourcePackOrganizer.Pack {
                 // Ensure the path only contains "a-z0-9_.-" characters
                 relativePath = relativePath.toLowerCase().replaceAll("[^a-zA-Z0-9_.-]", "_");
 
-                Identifier id = new Identifier("recursiveresources", "textures/gui/custom_folders/" + relativePath + "icon.png");
+                Identifier id = RecursiveResources.id("textures/gui/folder_icons/" + relativePath + "/" + icon.getFileName());
                 MinecraftClient.getInstance().getTextureManager().registerTexture(id, new NativeImageBackedTexture(NativeImage.read(stream)));
                 return id;
             } catch (Exception e) {

--- a/src/main/java/nl/enjarai/recursiveresources/pack/NestedFolderPackProvider.java
+++ b/src/main/java/nl/enjarai/recursiveresources/pack/NestedFolderPackProvider.java
@@ -59,17 +59,17 @@ public class NestedFolderPackProvider implements ResourcePackProvider {
 
         if (fileOrFolder.isDirectory()) {
             info = ResourcePackProfile.create(
-                new ResourcePackInfo(name, Text.literal(displayName), ResourcePackSource.NONE, Optional.empty()),
-                new DirectoryResourcePack.DirectoryBackedFactory(fileOrFolder.toPath()),
-                ResourceType.CLIENT_RESOURCES,
-                new ResourcePackPosition(false, InsertionPosition.TOP, false)
+                    new ResourcePackInfo(name, Text.literal(displayName), ResourcePackSource.NONE, Optional.empty()),
+                    new DirectoryResourcePack.DirectoryBackedFactory(fileOrFolder.toPath()),
+                    ResourceType.CLIENT_RESOURCES,
+                    new ResourcePackPosition(false, InsertionPosition.TOP, false)
             );
         } else {
             info = ResourcePackProfile.create(
-                new ResourcePackInfo(name, Text.literal(displayName), ResourcePackSource.NONE, Optional.empty()),
-                new ZipResourcePack.ZipBackedFactory(fileOrFolder),
-                ResourceType.CLIENT_RESOURCES,
-                new ResourcePackPosition(false, InsertionPosition.TOP, false)
+                    new ResourcePackInfo(name, Text.literal(displayName), ResourcePackSource.NONE, Optional.empty()),
+                    new ZipResourcePack.ZipBackedFactory(fileOrFolder),
+                    ResourceType.CLIENT_RESOURCES,
+                    new ResourcePackPosition(false, InsertionPosition.TOP, false)
             );
         }
 

--- a/src/main/java/nl/enjarai/recursiveresources/util/ResourcePackUtils.java
+++ b/src/main/java/nl/enjarai/recursiveresources/util/ResourcePackUtils.java
@@ -49,13 +49,13 @@ public class ResourcePackUtils {
             } else if (pack instanceof ZipResourcePack zipResourcePack) {
                 return ((ZipFileWrapperAccessor) ((ZipResourcePackAccessor) zipResourcePack).getZipFileWrapper()).getFile().toPath();
             } else if (pack instanceof ModNioResourcePack modResourcePack) {
-                return Path.of(modResourcePack.getId().replaceAll(UNSAFE_PATH_REGEX, "_"));
+                return Path.of(modResourcePack.toString().replaceAll(UNSAFE_PATH_REGEX, "_"));
             } else {
-                RecursiveResources.LOGGER.warn("Failed to determine source folder for pack: " + pack.getId() + ", unknown pack type: " + pack.getClass().getName());
+                RecursiveResources.LOGGER.warn("Failed to determine source folder for pack: " + pack.toString() + ", unknown pack type: " + pack.getClass().getName());
                 return null;
             }
         } catch (Exception e) {
-            RecursiveResources.LOGGER.error("Error determining source folder for pack: " + pack.getId(), e);
+            RecursiveResources.LOGGER.error("Error determining source folder for pack: " + pack.toString(), e);
             return null;
         }
     }

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -33,7 +33,7 @@
   "accessWidener": "recursiveresources.accesswidener",
 
   "depends": {
-    "minecraft": ">=1.20.5",
+    "minecraft": ">=1.21",
     "fabric-api": "*",
     "cicada": "*",
     "fabricloader": ">=0.15"


### PR DESCRIPTION
Updated the mod to 1.21. 

- Changed Gradle version to 8.8 
- Loom to 1.7-SNAPSHOT
- yamlang to '1.3.1
- yarn_mappings to 1.21+build.2
- fabric to fabric_version=0.100.3+1.21
- modmenu to 11.0.0

Fixed Updated Fabric and Minecraft Methods.

Changed the method for determing which packs to display by changing the line of code that looks for parent folder. Fixes issue raised by Shane were packs would not go into correct folders. Still cannot get symbolic links to work with these changes and I am not expert at UI so with the new 1.21 Minecraft UI some buttons may need to be moved around.